### PR TITLE
Add FastAPI sandbox with healthcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and start services
+        run: docker compose -f agentzero-commerce/docker-compose.yml up -d --build
+      - name: Wait for services
+        run: sleep 10
+      - name: Healthcheck
+        run: curl --fail http://localhost:8080/ga/healthcheck
+      - name: Shutdown
+        if: always()
+        run: docker compose -f agentzero-commerce/docker-compose.yml down

--- a/agentzero-commerce/Dockerfile
+++ b/agentzero-commerce/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY src/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src/ .
+CMD ["python", "main.py"]

--- a/agentzero-commerce/README.md
+++ b/agentzero-commerce/README.md
@@ -1,0 +1,12 @@
+# AgentZero Commerce Sandbox
+
+This folder contains a minimal FastAPI service exposing a single test endpoint for use with Open WebUI as a Tool Server.
+
+## Quick start
+1. **Clone** this repo and open the `agentzero-commerce` directory.
+2. Run `docker compose up --build` to start the API and a Postgres service.
+3. Test the service with `curl http://localhost:8080/ga/healthcheck`.
+4. View the OpenAPI schema at `http://localhost:8080/openapi.json`.
+5. In Open WebUI go to *Settings → OpenAPI Tool Servers → +* and enter `http://<host>:8080/openapi.json` to add the service.
+
+Prerequisites: Docker Desktop and `git`.

--- a/agentzero-commerce/docker-compose.yml
+++ b/agentzero-commerce/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+services:
+  agentzero-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - PYTHONUNBUFFERED=1
+
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: agentzero
+      POSTGRES_PASSWORD: agentzero
+      POSTGRES_DB: agentzero
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/agentzero-commerce/src/ga_client.py
+++ b/agentzero-commerce/src/ga_client.py
@@ -1,0 +1,1 @@
+# Placeholder for Google Analytics client

--- a/agentzero-commerce/src/main.py
+++ b/agentzero-commerce/src/main.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+app = FastAPI(title="AgentZero-Commerce API")
+
+@app.get("/ga/healthcheck", tags=["GA"])
+async def ga_health():
+    return JSONResponse({"status": "ok",
+                         "service": "google-analytics",
+                         "detail": "stub"})
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/agentzero-commerce/src/requirements.txt
+++ b/agentzero-commerce/src/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
## Summary
- add `agentzero-commerce` sandbox with Docker setup
- expose `/ga/healthcheck` endpoint
- document usage and Open WebUI integration
- add CI workflow that tests the endpoint via Docker Compose

## Testing
- `curl http://localhost:8080/ga/healthcheck`
- `curl http://localhost:8080/openapi.json | head -n 10`
- `docker compose up -d --build` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545b17c10c8331b86463a7aacf7139