### PR TITLE
Add remote backup sync feature

### DIFF
--- a/docker/backup_server/Dockerfile
+++ b/docker/backup_server/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /srv
+
+RUN pip install --no-cache-dir Flask
+
+COPY app.py ./app.py
+
+EXPOSE 8000
+CMD ["python", "app.py"]

--- a/docker/backup_server/app.py
+++ b/docker/backup_server/app.py
@@ -1,0 +1,22 @@
+from flask import Flask, request, send_file
+import os
+
+app = Flask(__name__)
+BASE_DIR = '/srv/data'
+BACKUP_FILE = os.path.join(BASE_DIR, 'backup.zip')
+
+@app.route('/backup', methods=['GET'])
+def download_backup():
+    if not os.path.exists(BACKUP_FILE):
+        return '', 404
+    return send_file(BACKUP_FILE, mimetype='application/zip')
+
+@app.route('/backup', methods=['POST'])
+def upload_backup():
+    os.makedirs(BASE_DIR, exist_ok=True)
+    with open(BACKUP_FILE, 'wb') as f:
+        f.write(request.get_data())
+    return 'ok'
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/docker/backup_server/build.txt
+++ b/docker/backup_server/build.txt
@@ -1,0 +1,8 @@
+# Build the backup server image
+cd docker/backup_server
+
+docker build -t a0-backup-server:local .
+
+# Run with the backups stored in ./data
+# (create the data directory on the host)
+docker run -d -p 8000:8000 -v $(pwd)/data:/srv/data a0-backup-server:local

--- a/docker/run/fs/ins/install_additional.sh
+++ b/docker/run/fs/ins/install_additional.sh
@@ -6,3 +6,7 @@ set -e
 
 # searxng - moved to base image
 # bash /ins/install_searxng.sh "$@"
+
+# extra runtime dependencies
+apt-get update
+apt-get install -y --no-install-recommends sqlite3 libsqlite3-dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ To begin with Agent Zero, follow the links below for detailed guides on various 
 - **[Architecture Overview](architecture.md):** Understand the internal workings of the framework.
 - **[Contributing](contribution.md):** Learn how to contribute to the Agent Zero project.
 - **[Troubleshooting and FAQ](troubleshooting.md):** Find answers to common issues and questions.
+- **[Remote Backup Server](remote_backup_server.md):** Optional service to keep your settings and files in sync.
 
 ### Your experience with Agent Zero starts now!
 

--- a/docs/remote_backup_server.md
+++ b/docs/remote_backup_server.md
@@ -37,3 +37,21 @@ if __name__ == '__main__':
 
 Store the server separately and configure `backup_url` in Agent Zero to point to
 its base URL (e.g. `http://your-vps:8000`).
+
+## Docker Deployment
+
+A ready-to-use `Dockerfile` is provided in `docker/backup_server/`.
+To build and run the server:
+
+```bash
+# Build the image
+cd docker/backup_server
+docker build -t a0-backup-server .
+
+# Start the server and persist backups in ./data
+mkdir -p data
+docker run -d -p 8000:8000 -v $(pwd)/data:/srv/data a0-backup-server
+```
+
+This container exposes the same `/backup` endpoints on port `8000`.
+Configure `backup_url` in Agent Zero to point to your container's URL.

--- a/docs/remote_backup_server.md
+++ b/docs/remote_backup_server.md
@@ -1,0 +1,39 @@
+# Remote Backup Server
+
+This simple Flask project exposes two REST endpoints used by Agent Zero to
+synchronize settings and workspace files.
+
+## Endpoints
+
+- `GET /backup` – returns a ZIP archive with the latest backup.
+- `POST /backup` – accepts a ZIP archive in the request body and stores it as the
+  current backup.
+
+## Example Implementation
+
+```python
+from flask import Flask, request, send_file
+import os, io, zipfile
+
+app = Flask(__name__)
+BACKUP_FILE = 'data/backup.zip'
+
+@app.route('/backup', methods=['GET'])
+def download_backup():
+    if not os.path.exists(BACKUP_FILE):
+        return '', 404
+    return send_file(BACKUP_FILE, mimetype='application/zip')
+
+@app.route('/backup', methods=['POST'])
+def upload_backup():
+    os.makedirs('data', exist_ok=True)
+    with open(BACKUP_FILE, 'wb') as f:
+        f.write(request.get_data())
+    return 'ok'
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)
+```
+
+Store the server separately and configure `backup_url` in Agent Zero to point to
+its base URL (e.g. `http://your-vps:8000`).

--- a/initialize.py
+++ b/initialize.py
@@ -162,3 +162,11 @@ def _set_runtime_config(config: AgentConfig, set: settings.Settings):
     #     dman.start_container()
 
     # config.code_exec_ssh_pass = asyncio.run(rfc_exchange.get_root_password())
+
+def initialize_backup_sync():
+    set = settings.get_settings()
+    async def start_sync():
+        from python.helpers import backup_sync
+        if set["backup_enabled"] and set["backup_url"]:
+            await backup_sync.start(set["backup_url"])
+    return defer.DeferredTask("BackupSync").start_task(start_sync)

--- a/python/api/backup_sync_now.py
+++ b/python/api/backup_sync_now.py
@@ -1,0 +1,11 @@
+from python.helpers.api import ApiHandler
+from flask import Request, Response
+from python.helpers import settings, backup_sync
+
+class BackupSyncNow(ApiHandler):
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        set = settings.get_settings()
+        if not set["backup_enabled"] or not set["backup_url"]:
+            return {"status": "disabled"}
+        ok = backup_sync.upload_backup(set["backup_url"])
+        return {"status": "ok" if ok else "error"}

--- a/python/helpers/backup_sync.py
+++ b/python/helpers/backup_sync.py
@@ -1,0 +1,90 @@
+import asyncio
+import os
+import io
+import zipfile
+from urllib import request, parse
+from python.helpers import files
+from python.helpers.print_style import PrintStyle
+
+WATCH_FOLDERS = ["tmp", "memory", "knowledge"]
+
+
+def _collect_files() -> dict[str, float]:
+    base = files.get_base_dir()
+    mapping: dict[str, float] = {}
+    for folder in WATCH_FOLDERS:
+        path = files.get_abs_path(folder)
+        if not os.path.exists(path):
+            continue
+        for root, _dirs, file_names in os.walk(path):
+            for name in file_names:
+                full = os.path.join(root, name)
+                try:
+                    mapping[os.path.relpath(full, base)] = os.path.getmtime(full)
+                except FileNotFoundError:
+                    pass
+    return mapping
+
+
+def _create_zip() -> bytes:
+    base = files.get_base_dir()
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for rel, _ in _collect_files().items():
+            abs_path = os.path.join(base, rel)
+            if os.path.isfile(abs_path):
+                zf.write(abs_path, rel)
+    return buf.getvalue()
+
+
+def _extract_zip(data: bytes):
+    base = files.get_base_dir()
+    buf = io.BytesIO(data)
+    with zipfile.ZipFile(buf) as zf:
+        zf.extractall(base)
+
+
+def download_backup(url: str) -> bool:
+    try:
+        with request.urlopen(f"{url.rstrip('/')}/backup") as resp:
+            if resp.status != 200:
+                PrintStyle.error(f"Backup server error: {resp.status}")
+                return False
+            data = resp.read()
+            _extract_zip(data)
+            PrintStyle.debug("Backup downloaded")
+            return True
+    except Exception as e:
+        PrintStyle.error(f"Download failed: {e}")
+        return False
+
+
+def upload_backup(url: str) -> bool:
+    data = _create_zip()
+    req = request.Request(
+        f"{url.rstrip('/')}/backup",
+        method="POST",
+        data=data,
+        headers={"Content-Type": "application/zip"},
+    )
+    try:
+        with request.urlopen(req) as resp:
+            if resp.status != 200:
+                PrintStyle.error(f"Upload failed: {resp.status}")
+                return False
+            PrintStyle.debug("Backup uploaded")
+            return True
+    except Exception as e:
+        PrintStyle.error(f"Upload error: {e}")
+        return False
+
+
+async def start(url: str):
+    download_backup(url)
+    previous = _collect_files()
+    while True:
+        await asyncio.sleep(30)
+        current = _collect_files()
+        if current != previous:
+            upload_backup(url)
+            previous = current

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -70,6 +70,8 @@ class Settings(TypedDict):
     mcp_client_tool_timeout: int
     mcp_server_enabled: bool
     mcp_server_token: str
+    backup_enabled: bool
+    backup_url: str
 
 
 class PartialSettings(Settings, total=False):
@@ -770,6 +772,47 @@ def convert_out(settings: Settings) -> SettingsOutput:
         "tab": "mcp",
     }
 
+    backup_fields: list[SettingsField] = []
+
+    backup_fields.append(
+        {
+            "id": "backup_enabled",
+            "title": "Enable Backup Sync",
+            "description": "Automatically sync settings and memory with a remote backup server.",
+            "type": "switch",
+            "value": settings["backup_enabled"],
+        }
+    )
+
+    backup_fields.append(
+        {
+            "id": "backup_url",
+            "title": "Backup Server URL",
+            "description": "URL of the remote backup API.",
+            "type": "text",
+            "value": settings["backup_url"],
+        }
+    )
+
+    backup_fields.append(
+        {
+            "id": "backup_sync_now",
+            "title": "Sync Now",
+            "description": "Trigger immediate synchronization with the backup server.",
+            "type": "button",
+            "value": "Sync Now",
+            "action": "backup_sync_now",
+        }
+    )
+
+    backup_section: SettingsSection = {
+        "id": "backup",
+        "title": "Remote Backup",
+        "description": "Configure remote backup server.",
+        "fields": backup_fields,
+        "tab": "developer",
+    }
+
     # Add the section to the result
     result: SettingsOutput = {
         "sections": [
@@ -784,6 +827,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
             auth_section,
             mcp_client_section,
             mcp_server_section,
+            backup_section,
             dev_section,
         ]
     }
@@ -958,6 +1002,8 @@ def get_default_settings() -> Settings:
         mcp_client_tool_timeout=120,
         mcp_server_enabled=False,
         mcp_server_token=create_auth_token(),
+        backup_enabled=False,
+        backup_url="",
     )
 
 

--- a/run_ui.py
+++ b/run_ui.py
@@ -235,6 +235,8 @@ def init_a0():
     initialize.initialize_mcp()
     # start job loop
     initialize.initialize_job_loop()
+    # start backup sync
+    initialize.initialize_backup_sync()
 
     # only wait for init chats, otherwise they would seem to dissapear for a while on restart
     init_chats.result_sync()

--- a/webui/js/settings.js
+++ b/webui/js/settings.js
@@ -287,6 +287,9 @@ const settingsModalProxy = {
 
         if (field.id === "mcp_servers_config") {
             openModal("settings/mcp/client/mcp-servers.html");
+        } else if (field.action === 'backup_sync_now') {
+            await fetch('/backup_sync_now', {method: 'POST'});
+            showToast('Backup sync triggered', 'success');
         }
     }
 };
@@ -454,6 +457,10 @@ document.addEventListener('alpine:init', function () {
                     this.revealToken(field);
                 } else if (field.action === 'generate_token') {
                     this.generateToken(field);
+                } else if (field.action === 'backup_sync_now') {
+                    fetch('/backup_sync_now', {method: 'POST'}).then(() => {
+                        showToast('Backup sync triggered', 'success');
+                    });
                 } else {
                     console.warn('Unknown button action:', field.action);
                 }


### PR DESCRIPTION
## Summary
- add backup sync helper and API endpoint
- integrate backup server settings into UI
- start backup sync on server init
- document remote backup server implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857fadb6400833198157b6ad3993dd2